### PR TITLE
fix: change the setting of timzone

### DIFF
--- a/backend/model/orderSummaryModel.js
+++ b/backend/model/orderSummaryModel.js
@@ -1,6 +1,5 @@
 import { pool } from './util.js';
 import moment from 'moment-timezone';
-moment.tz.setDefault("Asia/Taipei");
 
 export async function getOrderSummary(restaurantId) {
 try {


### PR DESCRIPTION
1.我改了一個小東西：
把程式的時區設定刪掉，因為我之前有在mysql設定過了，(不過如果mysql有重啟的話好像設定會消失，要留意一下）
由於本地和EC2的時區設置不同會導致回傳的時間差了八小時
